### PR TITLE
Scope Livewire loading skeletons for document views

### DIFF
--- a/resources/views/livewire/documents/document-edit.blade.php
+++ b/resources/views/livewire/documents/document-edit.blade.php
@@ -22,58 +22,7 @@
         </div>
     @endif
 
-    <div wire:loading wire:target="niveau_id,ue_id,ec_id" aria-busy="true" class="grid grid-cols-1 lg:grid-cols-12 gap-6">
-        <div class="lg:col-span-8 space-y-6">
-            <div class="rounded-xl border border-gray-200/70 dark:border-gray-800/70 bg-white dark:bg-gray-800 p-5 space-y-4">
-                <x-skeleton.line width="w-32" height="h-5" />
-                <div class="space-y-2">
-                    <x-skeleton.line width="w-24" height="h-4" />
-                    <x-skeleton.line width="w-full" height="h-11" class="rounded-lg" />
-                </div>
-                <div class="grid grid-cols-1 md:grid-cols-3 gap-4">
-                    <div class="space-y-2">
-                        <x-skeleton.line width="w-24" height="h-4" />
-                        <x-skeleton.line width="w-full" height="h-11" class="rounded-lg" />
-                    </div>
-                    <div class="space-y-2">
-                        <x-skeleton.line width="w-20" height="h-4" />
-                        <x-skeleton.line width="w-full" height="h-11" class="rounded-lg" />
-                    </div>
-                    <div class="space-y-2">
-                        <x-skeleton.line width="w-24" height="h-4" />
-                        <x-skeleton.line width="w-full" height="h-11" class="rounded-lg" />
-                    </div>
-                </div>
-            </div>
-            <div class="rounded-xl border border-gray-200/70 dark:border-gray-800/70 bg-white dark:bg-gray-800 p-5 space-y-4">
-                <div class="flex items-center justify-between gap-3">
-                    <x-skeleton.line width="w-24" height="h-5" />
-                    <x-skeleton.line width="w-28" height="h-3" />
-                </div>
-                <div class="grid grid-cols-1 sm:grid-cols-3 gap-2">
-                    <x-skeleton.button width="w-full" height="h-10" />
-                    <x-skeleton.button width="w-full" height="h-10" />
-                    <x-skeleton.button width="w-full" height="h-10" />
-                </div>
-                <x-skeleton.line width="w-full" height="h-16" class="rounded-lg" />
-            </div>
-        </div>
-        <aside class="lg:col-span-4 space-y-4">
-            <div class="rounded-xl border border-gray-200/70 dark:border-gray-800/70 bg-white dark:bg-gray-800 p-4 space-y-4">
-                <x-skeleton.line width="w-20" height="h-4" />
-                <div class="grid grid-cols-1 sm:grid-cols-2 gap-3">
-                    <x-skeleton.button width="w-full" height="h-10" />
-                    <x-skeleton.button width="w-full" height="h-10" />
-                </div>
-                <div class="flex gap-2">
-                    <x-skeleton.button width="w-full" height="h-10" />
-                    <x-skeleton.button width="w-full" height="h-10" />
-                </div>
-            </div>
-        </aside>
-    </div>
-
-    <form wire:submit.prevent="save" wire:loading.remove wire:target="niveau_id,ue_id,ec_id" class="grid grid-cols-1 lg:grid-cols-12 gap-6">
+    <form wire:submit.prevent="save" class="grid grid-cols-1 lg:grid-cols-12 gap-6">
 
         <div class="lg:col-span-8 space-y-6">
 
@@ -91,7 +40,9 @@
                 </div>
 
                 {{-- Niveau -> UE -> EC (Programme) --}}
-                <div class="grid grid-cols-1 md:grid-cols-3 gap-4">
+                <div class="grid grid-cols-1 md:grid-cols-3 gap-4"
+                     wire:loading.attr="aria-busy"
+                     wire:target="niveau_id,ue_id">
                     <div>
                         <label class="block text-sm font-semibold text-gray-700 dark:text-gray-300 mb-1">
                             Niveau <span class="text-red-500">*</span>
@@ -110,14 +61,19 @@
                         <label class="block text-sm font-semibold text-gray-700 dark:text-gray-300 mb-1">
                             UE <span class="text-red-500">*</span>
                         </label>
-                        <select wire:model.live="ue_id"
-                                class="w-full h-11 rounded-lg border border-gray-300 dark:border-gray-700 bg-white dark:bg-gray-800 px-3 text-sm text-gray-900 dark:text-white focus:border-indigo-500 focus:ring-indigo-500"
-                                @if(!$niveau_id) disabled @endif>
-                            <option value="">Sélectionnez</option>
-                            @foreach($ues as $ue)
-                                <option value="{{ $ue->id }}">{{ $ue->code }} — {{ $ue->name }}</option>
-                            @endforeach
-                        </select>
+                        <div wire:loading.remove wire:target="niveau_id">
+                            <select wire:model.live="ue_id"
+                                    class="w-full h-11 rounded-lg border border-gray-300 dark:border-gray-700 bg-white dark:bg-gray-800 px-3 text-sm text-gray-900 dark:text-white focus:border-indigo-500 focus:ring-indigo-500"
+                                    @if(!$niveau_id) disabled @endif>
+                                <option value="">Sélectionnez</option>
+                                @foreach($ues as $ue)
+                                    <option value="{{ $ue->id }}">{{ $ue->code }} — {{ $ue->name }}</option>
+                                @endforeach
+                            </select>
+                        </div>
+                        <div wire:loading.delay wire:target="niveau_id" class="space-y-2" aria-busy="true">
+                            <x-skeleton.line width="w-full" height="h-11" class="rounded-lg" />
+                        </div>
                         @error('ue_id') <p class="mt-1 text-xs font-semibold text-red-600 dark:text-red-400">{{ $message }}</p> @enderror
                     </div>
 
@@ -125,14 +81,19 @@
                         <label class="block text-sm font-semibold text-gray-700 dark:text-gray-300 mb-1">
                             EC (optionnel)
                         </label>
-                        <select wire:model.live="ec_id"
-                                class="w-full h-11 rounded-lg border border-gray-300 dark:border-gray-700 bg-white dark:bg-gray-800 px-3 text-sm text-gray-900 dark:text-white focus:border-indigo-500 focus:ring-indigo-500"
-                                @if(!$ue_id || $ecs->isEmpty()) disabled @endif>
-                            <option value="">Toute l’UE</option>
-                            @foreach($ecs as $ec)
-                                <option value="{{ $ec->id }}">{{ $ec->code }} — {{ $ec->name }}</option>
-                            @endforeach
-                        </select>
+                        <div wire:loading.remove wire:target="niveau_id,ue_id">
+                            <select wire:model.live="ec_id"
+                                    class="w-full h-11 rounded-lg border border-gray-300 dark:border-gray-700 bg-white dark:bg-gray-800 px-3 text-sm text-gray-900 dark:text-white focus:border-indigo-500 focus:ring-indigo-500"
+                                    @if(!$ue_id || $ecs->isEmpty()) disabled @endif>
+                                <option value="">Toute l’UE</option>
+                                @foreach($ecs as $ec)
+                                    <option value="{{ $ec->id }}">{{ $ec->code }} — {{ $ec->name }}</option>
+                                @endforeach
+                            </select>
+                        </div>
+                        <div wire:loading.delay wire:target="niveau_id,ue_id" class="space-y-2" aria-busy="true">
+                            <x-skeleton.line width="w-full" height="h-11" class="rounded-lg" />
+                        </div>
                         @error('ec_id') <p class="mt-1 text-xs font-semibold text-red-600 dark:text-red-400">{{ $message }}</p> @enderror
                     </div>
                 </div>

--- a/resources/views/livewire/documents/document-upload.blade.php
+++ b/resources/views/livewire/documents/document-upload.blade.php
@@ -48,81 +48,18 @@
     @enderror
 
 
-    <div wire:loading wire:target="uploadDocuments,files,links,niveau_id,ue_id,ec_id,source" aria-busy="true" class="space-y-6">
-        <div class="grid grid-cols-1 lg:grid-cols-12 gap-6">
-            <div class="lg:col-span-8 space-y-6">
-                <div class="rounded-xl border border-gray-200/70 dark:border-gray-800/70 bg-white dark:bg-gray-800 p-5 space-y-4">
-                    <div class="flex items-center justify-between gap-3">
-                        <x-skeleton.line width="w-32" height="h-5" />
-                        <x-skeleton.line width="w-24" height="h-3" />
-                    </div>
-                    <div class="grid grid-cols-1 md:grid-cols-2 gap-4">
-                        <div class="space-y-2">
-                            <x-skeleton.line width="w-24" height="h-4" />
-                            <x-skeleton.line width="w-full" height="h-11" class="rounded-lg" />
-                        </div>
-                        <div class="space-y-2">
-                            <x-skeleton.line width="w-24" height="h-4" />
-                            <x-skeleton.line width="w-full" height="h-11" class="rounded-lg" />
-                        </div>
-                        <div class="space-y-2 md:col-span-2">
-                            <x-skeleton.line width="w-32" height="h-4" />
-                            <x-skeleton.line width="w-full" height="h-11" class="rounded-lg" />
-                        </div>
-                    </div>
-                </div>
-
-                <div class="rounded-xl border border-gray-200/70 dark:border-gray-800/70 bg-white dark:bg-gray-800 p-5 space-y-4">
-                    <div class="flex items-center justify-between gap-3">
-                        <x-skeleton.line width="w-24" height="h-5" />
-                        <x-skeleton.line width="w-40" height="h-3" />
-                    </div>
-                    <div class="space-y-3">
-                        <x-skeleton.line width="w-28" height="h-4" />
-                        <div class="flex flex-wrap gap-2">
-                            <x-skeleton.button width="w-36" height="h-9" />
-                            <x-skeleton.button width="w-44" height="h-9" />
-                        </div>
-                        <x-skeleton.line width="w-full" height="h-28" class="rounded-xl" />
-                        <x-skeleton.line width="w-64" height="h-3" />
-                    </div>
-                </div>
-            </div>
-            <div class="lg:col-span-4 space-y-6">
-                <div class="rounded-xl border border-gray-200/70 dark:border-gray-800/70 bg-white dark:bg-gray-800 p-4 space-y-4">
-                    <div class="flex items-center justify-between">
-                        <x-skeleton.line width="w-32" height="h-4" />
-                        <x-skeleton.line width="w-10" height="h-3" />
-                    </div>
-                    <div class="space-y-3">
-                        <x-skeleton.line width="w-full" height="h-16" class="rounded-lg" />
-                        <x-skeleton.line width="w-full" height="h-16" class="rounded-lg" />
-                    </div>
-                </div>
-                <div class="rounded-xl border border-gray-200/70 dark:border-gray-800/70 bg-white dark:bg-gray-800 p-4 space-y-3">
-                    <div class="flex items-center justify-between">
-                        <x-skeleton.line width="w-20" height="h-4" />
-                        <x-skeleton.line width="w-16" height="h-3" />
-                    </div>
-                    <div class="flex gap-2">
-                        <x-skeleton.button width="w-full" height="h-10" />
-                        <x-skeleton.button width="w-full" height="h-10" />
-                    </div>
-                </div>
-            </div>
-        </div>
-    </div>
-
     <form wire:submit.prevent="uploadDocuments"
           wire:loading.remove
-          wire:target="uploadDocuments,files,links,niveau_id,ue_id,ec_id,source">
+          wire:target="uploadDocuments,files,links,source">
         <div class="grid grid-cols-1 lg:grid-cols-12 gap-6">
 
             {{-- LEFT --}}
             <div class="lg:col-span-8 space-y-6">
 
                 {{-- Destination --}}
-                <div class="rounded-xl border border-gray-200 dark:border-gray-800 bg-white dark:bg-gray-800 p-5">
+                <div class="rounded-xl border border-gray-200 dark:border-gray-800 bg-white dark:bg-gray-800 p-5"
+                     wire:loading.attr="aria-busy"
+                     wire:target="niveau_id,ue_id">
                     <div class="flex items-center justify-between gap-3">
                         <h2 class="text-base font-bold text-gray-900 dark:text-white">
                             Destination
@@ -161,14 +98,19 @@
                             <label class="block text-sm font-semibold text-gray-700 dark:text-gray-300 mb-1">
                                 UE <span class="text-red-500">*</span>
                             </label>
-                            <select wire:model.live="ue_id"
-                                    class="w-full h-11 rounded-lg border border-gray-300 dark:border-gray-700 bg-white dark:bg-gray-800 px-3 text-sm text-gray-900 dark:text-white focus:border-indigo-500 focus:ring-indigo-500"
-                                    @if(!$niveau_id) disabled @endif>
-                                <option value="">Sélectionnez</option>
-                                @foreach($ues as $ue)
-                                    <option value="{{ $ue->id }}">{{ $ue->code }} — {{ $ue->name }}</option>
-                                @endforeach
-                            </select>
+                            <div wire:loading.remove wire:target="niveau_id">
+                                <select wire:model.live="ue_id"
+                                        class="w-full h-11 rounded-lg border border-gray-300 dark:border-gray-700 bg-white dark:bg-gray-800 px-3 text-sm text-gray-900 dark:text-white focus:border-indigo-500 focus:ring-indigo-500"
+                                        @if(!$niveau_id) disabled @endif>
+                                    <option value="">Sélectionnez</option>
+                                    @foreach($ues as $ue)
+                                        <option value="{{ $ue->id }}">{{ $ue->code }} — {{ $ue->name }}</option>
+                                    @endforeach
+                                </select>
+                            </div>
+                            <div wire:loading.delay wire:target="niveau_id" class="space-y-2" aria-busy="true">
+                                <x-skeleton.line width="w-full" height="h-11" class="rounded-lg" />
+                            </div>
                             @error('ue_id')
                                 <p class="mt-1 text-xs font-semibold text-red-600 dark:text-red-400">{{ $message }}</p>
                             @enderror
@@ -179,14 +121,19 @@
                             <label class="block text-sm font-semibold text-gray-700 dark:text-gray-300 mb-1">
                                 EC (optionnel)
                             </label>
-                            <select wire:model.live="ec_id"
-                                    class="w-full h-11 rounded-lg border border-gray-300 dark:border-gray-700 bg-white dark:bg-gray-800 px-3 text-sm text-gray-900 dark:text-white focus:border-indigo-500 focus:ring-indigo-500"
-                                    @if(!$ue_id || $ecs->isEmpty()) disabled @endif>
-                                <option value="">Toute l’UE</option>
-                                @foreach($ecs as $ec)
-                                    <option value="{{ $ec->id }}">{{ $ec->code }} — {{ $ec->name }}</option>
-                                @endforeach
-                            </select>
+                            <div wire:loading.remove wire:target="niveau_id,ue_id">
+                                <select wire:model.live="ec_id"
+                                        class="w-full h-11 rounded-lg border border-gray-300 dark:border-gray-700 bg-white dark:bg-gray-800 px-3 text-sm text-gray-900 dark:text-white focus:border-indigo-500 focus:ring-indigo-500"
+                                        @if(!$ue_id || $ecs->isEmpty()) disabled @endif>
+                                    <option value="">Toute l’UE</option>
+                                    @foreach($ecs as $ec)
+                                        <option value="{{ $ec->id }}">{{ $ec->code }} — {{ $ec->name }}</option>
+                                    @endforeach
+                                </select>
+                            </div>
+                            <div wire:loading.delay wire:target="niveau_id,ue_id" class="space-y-2" aria-busy="true">
+                                <x-skeleton.line width="w-full" height="h-11" class="rounded-lg" />
+                            </div>
                             @error('ec_id')
                                 <p class="mt-1 text-xs font-semibold text-red-600 dark:text-red-400">{{ $message }}</p>
                             @enderror


### PR DESCRIPTION
### Motivation
- The global `wire:loading` skeleton on the document upload/edit pages blocked unrelated areas (Files/Source/Actions) and produced incorrect heights and flicker when `wire:model.live` triggered rapid requests. 
- Loading should be scoped to the parts that actually change (Destination / Programme selects) so users can still interact with other zones. 
- Use `wire:loading.delay` to avoid flicker for very short requests and keep accessibility via `aria-busy` on the loading area only. 
- No functional/validation changes; this is purely a UX/markup refinement.

### Description
- Removed the global skeleton wrapper from `resources/views/livewire/documents/document-upload.blade.php` and `resources/views/livewire/documents/document-edit.blade.php` so the page is no longer fully masked during select changes. 
- Scoped loaders to the Destination/Programme areas by adding `wire:loading.remove`/`wire:loading.delay` blocks around the `UE`/`EC` selects and using `wire:target="niveau_id,ue_id"` (and `niveau_id,ue_id` where appropriate) to precisely target select-related requests. 
- Added `wire:loading.attr="aria-busy"` on the destination/programme container to preserve accessibility while limiting `aria-busy` to the loading zone only, and adjusted skeleton line heights to match actual input heights (`h-11`). 
- Adjusted form-level `wire:target` for upload to `uploadDocuments,files,links,source` so select changes do not disable or block the Files/Source/ACTIONS panel, and kept the existing overlay include unchanged.

### Testing
- No automated tests were executed for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69595d3428008333a2d7291a70708219)